### PR TITLE
ci: remove dev branch restriction from auto-release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,9 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     # Condition adaptée pour les deux types de déclenchement
     if: |
-      (github.event_name == 'pull_request' && 
-       github.event.pull_request.merged == true && 
-       github.event.pull_request.head.ref == 'dev') ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.merged == true) ||
       (github.event_name == 'workflow_dispatch')
 
     steps:


### PR DESCRIPTION
## Summary
- Remove the `head.ref == 'dev'` condition from the auto-release workflow
- External contributors submit PRs from feature branches (not `dev`), so the release was **skipped** when merging their PRs (e.g. #11)
- Now any merged PR into `main` with a version in the title triggers the release

## Context
PR #11 by @fonpacific was merged but the auto-release for v1.1.4 was skipped because the source branch was `fix-additional-webspace-property-name` instead of `dev`. A manual trigger was needed to create the release.